### PR TITLE
Fix test url and puppet pathing, rework calls to puppet, add .exe to windows files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,12 @@ mkdir -p ${release_path}
 for target in $targets; do
   os="$(echo $target | cut -d '/' -f1)"
   arch="$(echo $target | cut -d '/' -f2)"
-  output="${release_path}/${repo_name}_${os}_${arch}"
+
+  if [ "$os" = "windows" ]; then
+    output="${release_path}/${repo_name}_${os}_${arch}.exe"
+  else
+    output="${release_path}/${repo_name}_${os}_${arch}"
+  fi
 
   echo "----> Building project for: $target"
   GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $output

--- a/puppet-cron.go
+++ b/puppet-cron.go
@@ -89,6 +89,8 @@ func isValidEnvironment(environment string) bool {
 	server := puppetConfigGet("agent", "server")
 	port := puppetConfigGet("agent", "masterport")
 
+	log.Printf("Checking if environment '%s' exists on '%s'", environment, server)
+
 	url := fmt.Sprintf("https://%s:%s/puppet/v3/file_metadatas/plugins?environment=%s", server, port, environment)
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -120,6 +122,7 @@ func main() {
 		puppetConfigSet("agent", "environment", "production")
 	}
 
+	log.Print("starting puppet run...")
 	err := syscall.Exec(puppetBinary, []string{"puppet", "agent", "--no-daemonize", "--onetime"}, os.Environ())
 	if err != nil {
 		log.Fatal(err)

--- a/puppet-cron.go
+++ b/puppet-cron.go
@@ -80,7 +80,7 @@ func isValidEnvironment(environment string) bool {
 	server := puppetConfigGet("agent", "server")
 	port := puppetConfigGet("agent", "masterport")
 
-	url := fmt.Sprintf("https://%s:%s/puppet/v3/status/test?environment=%s", server, port, environment)
+	url := fmt.Sprintf("https://%s:%s/puppet/v3/file_metadatas/plugins?environment=%s", server, port, environment)
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		log.Panic(err)

--- a/puppet-cron.go
+++ b/puppet-cron.go
@@ -11,41 +11,55 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
-	"syscall"
 	"time"
 )
 
-func getPuppetPath() string {
-	if runtime.GOOS == "windows" {
-		return string("C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat")
-	} else {
-		return string("/opt/puppetlabs/bin/puppet")
+// Call the installed version of Puppet with a given set of arguments.
+// It returns the output to the calling function as a byte array.
+func callPuppet(puppetArgs []string) []byte {
+	paths := []string{}
+
+	if os.Getenv("PATH") != "" {
+		paths = append(paths, os.Getenv("PATH"))
 	}
+
+	if runtime.GOOS == "windows" {
+		defaultPuppetLocation := string("C:\\Program Files\\Puppet Labs\\Puppet\\bin")
+		paths = append(paths, defaultPuppetLocation)
+		os.Setenv("PATH", strings.Join(paths, ";"))
+	} else {
+		defaultPuppetLocation := string("/opt/puppetlabs/bin")
+		paths = append(paths, defaultPuppetLocation)
+		os.Setenv("PATH", strings.Join(paths, ":"))
+	}
+
+	output, err := exec.Command("puppet", puppetArgs...).Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return output
 }
 
-// We use `puppet config` to get and set values in
-// /etc/puppetlabs/puppet/puppet.conf. We don't touch it directly at all.
-
+// Use `puppet config print` to retrieve the value of a given key
+// from a given section of puppet.conf.
+// The value is returned as a string to the callling function.
 func puppetConfigGet(section string, key string) string {
 	args := []string{"config", "print", "--section", section, key}
-	puppetBinary := getPuppetPath()
+	output := callPuppet(args)
 
-	output, err := exec.Command(puppetBinary, args...).Output()
-	if err != nil {
-		log.Fatalf("Failed: %s %s", puppetBinary, strings.Join(args, " "))
-	}
-
-	return string(output[:len(output)-1])
+	value := string(output[:len(output)-1])
+	value = strings.ReplaceAll(value, "\r", "")
+	value = strings.ReplaceAll(value, "\n", "")
+	return value
 }
 
+// use `puppet config set` to set the value of a given key in a given
+// section of puppet.conf
 func puppetConfigSet(section string, key string, value string) {
 	args := []string{"config", "set", "--section", section, key, value}
-	puppetBinary := getPuppetPath()
 
-	_, err := exec.Command(puppetBinary, args...).Output()
-	if err != nil {
-		log.Fatalf("Failed: %s %s", puppetBinary, strings.Join(args, " "))
-	}
+	callPuppet(args)
 }
 
 // Create an http.Client that recognizes the Puppet CA, and authenticates with
@@ -113,21 +127,24 @@ func isValidEnvironment(environment string) bool {
 	return true
 }
 
+// Check to see if the locally configured puppet environment still exists.
+// If it doesn't, revert to the `production` envionment. Once the check
+// and any needed update is complete, run the puppet agent.
 func main() {
+	log.Print("Starting puppet-cron...")
 	environment := puppetConfigGet("agent", "environment")
-	puppetBinary := getPuppetPath()
+	puppetArgs := []string{"agent", "--no-daemonize", "--onetime"}
 
 	if environment == "" || !isValidEnvironment(environment) {
 		log.Printf("Environment %q is invalid; resetting", environment)
 		puppetConfigSet("agent", "environment", "production")
 	}
 
-	log.Print("starting puppet run...")
-	err := syscall.Exec(puppetBinary, []string{"puppet", "agent", "--no-daemonize", "--onetime"}, os.Environ())
-	if err != nil {
-		log.Fatal(err)
-	} else {
-		// WTF. exec should only return if it fails
-		log.Panic("syscall.Exec returned with no error")
+	if os.Getenv("PUPPET_CRON_DEBUG") != "" {
+		log.Printf("Current value of $PATH: %s", os.Getenv("PATH"))
 	}
+
+	log.Printf("Running 'puppet %s'", strings.Join(puppetArgs, " "))
+
+	callPuppet(puppetArgs)
 }


### PR DESCRIPTION
- Fix url used to check if a puppet environment exists
- set the path to puppet based on OS
- added some additional runtime output to make things less mysterious
- Reworked executing puppet, added more output. Prior to this, two different types of execution were in use, one of which was not cross platform. Calls to puppet were also done in multiple places. After this change there is a single function that handles all calls to puppet. This function uses the existing PATH and appends the default location of Puppet while taking into account that there are differences on Windows. Some initial debug output was also added that is only shown if the `PUPPET_CRON_DEBUG` environment variable is set.
- Added `.exe` to the binary files built for Windows