### PR TITLE
Rename from puppet-cron to puppet-runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wrapper for running the puppet agent from cron
+# A wrapper for running the puppet agent
 
 Our workflow is to develop changes in feature branches, which become
 environments. Once those branches are merged, they are deleted from the repo and
@@ -16,13 +16,13 @@ macOS, Solaris, and Windows.
 
 ### Linux, macOS, Solaris x86
 
-Assuming you have installed this to `/usr/local/bin/puppet-cron`, create a cron job similar
+Assuming you have installed this to `/usr/local/bin/puppet-runner`, create a cron job similar
 to the one below. The reason for the path information is so that facts will be resolved
 correctly.
 
 ```bash
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin
-0,30 * * * * /usr/local/bin/puppet-cron
+0,30 * * * * /usr/local/bin/puppet-runner
 ```
 
 If there is an error, or if the environment is reset to `production`, the
@@ -30,7 +30,7 @@ wrapper will write to stdout, and thus generate an email.
 
 ### Windows
 
-Configure a scheduled task to run `puppet-cron` every thirty minutes.
+Configure a scheduled task to run `puppet-runner` every thirty minutes.
 
 ## Building
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/puppetlabs-operations/puppet-cron
+module github.com/puppetlabs-operations/puppet-runner
 
 go 1.16

--- a/puppet-runner.go
+++ b/puppet-runner.go
@@ -131,7 +131,7 @@ func isValidEnvironment(environment string) bool {
 // If it doesn't, revert to the `production` envionment. Once the check
 // and any needed update is complete, run the puppet agent.
 func main() {
-	log.Print("Starting puppet-cron...")
+	log.Print("Starting puppet-runner...")
 	environment := puppetConfigGet("agent", "environment")
 	puppetArgs := []string{"agent", "--no-daemonize", "--onetime"}
 
@@ -140,7 +140,7 @@ func main() {
 		puppetConfigSet("agent", "environment", "production")
 	}
 
-	if os.Getenv("PUPPET_CRON_DEBUG") != "" {
+	if os.Getenv("PUPPET_RUNNER_DEBUG") != "" {
 		log.Printf("Current value of $PATH: %s", os.Getenv("PATH"))
 	}
 


### PR DESCRIPTION
This application actually has nothing to do with cron so it needed a new name. DIO voted on a couple of choices and puppet-runner won out.